### PR TITLE
major refactor, better params, several bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ OPTIONS
 EXAMPLES
     dnslink-dnsimple -t $(cat dnsimple-token) -d domain.net -r _dnslink -l /ipns/ipfs.io
 ```
+
+## Install
+
+```
+go get github.com/ipfs/dnslink-dnsimple
+```
+
+## LICENSE
+
+```
+MIT
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # dnslink-dnsimple
+
 Update dnslink TXT records in DNSimple
+
+## Usage
+
+```
+> dnslink-dnsimple -h
+USAGE
+    dnslink-dnsimple -t <api-token> -d <domain-name> [-r <record-name>] -l <dnslink-value>
+
+OPTIONS
+    -t, --token <string>    dnsimple api token (required)
+    -l, --link  <string>    dnslink value, eg. ipfs path (required)
+    -d, --domain <string>   dnsimple domain name (required)
+    -r, --record <string>   domain record name
+    -v, --verbose           show logging output
+    -h, --help              show this documentation
+    --ttl <int>             set the ttl of the record (default: 60)
+
+EXAMPLES
+    dnslink-dnsimple -t $(cat dnsimple-token) -d domain.net -r _dnslink -l /ipns/ipfs.io
+```

--- a/main.go
+++ b/main.go
@@ -3,80 +3,210 @@ package main
 import (
 	"fmt"
 	"os"
+	"errors"
+	"io/ioutil"
 	"strings"
+	"flag"
+	logging "log"
 
-	dnsimple "github.com/dnsimple/dnsimple-go/dnsimple"
+	dns "github.com/dnsimple/dnsimple-go/dnsimple"
 )
 
-func printError(token string, err string) {
-	err = strings.Replace(err, token, "", -1)
-	fmt.Println(err)
+var log *logging.Logger
+
+type Args struct{
+	Token   string
+	Domain  string
+	RecName string
+	Link    string
+	Verbose bool
+	TTL     int
+}
+
+const (
+	DnslinkPrefix = "dnslink="
+	DefaultTTL    = 60
+	TXT           = "TXT"
+)
+
+var Usage = `
+USAGE
+		dnslink-dnsimple -t <api-token> -d <domain-name> [-r <record-name>] -l <dnslink-value>
+
+OPTIONS
+		-t, --token <string>    dnsimple api token (required)
+		-l, --link  <string>    dnslink value, eg. ipfs path (required)
+		-d, --domain <string>   dnsimple domain name (required)
+		-r, --record <string>   domain record name
+		-v, --verbose           show logging output
+		-h, --help              show this documentation
+		--ttl <int>             set the ttl of the record (default: 60)
+
+EXAMPLES
+		dnslink-dnsimple -t $(cat dnsimple-token) -d domain.net -r _dnslink -l /ipns/ipfs.io
+`
+
+func parseArgs() (Args, error) {
+	var a Args
+	flag.StringVar(&a.Token, "t", "", "")
+	flag.StringVar(&a.Token, "token", "", "")
+	flag.StringVar(&a.Domain, "d", "", "")
+	flag.StringVar(&a.Domain, "domain", "", "")
+	flag.StringVar(&a.RecName, "r", "", "")
+	flag.StringVar(&a.RecName, "record", "", "")
+	flag.StringVar(&a.Link, "l", "", "")
+	flag.StringVar(&a.Link, "link", "", "")
+	flag.BoolVar(&a.Verbose, "v", false, "")
+	flag.BoolVar(&a.Verbose, "verbose", false, "")
+	flag.IntVar(&a.TTL, "ttl", DefaultTTL, "")
+
+  flag.Usage = func() {
+    fmt.Fprintf(os.Stderr, Usage)
+  }
+	flag.Parse()
+	if a.Token == "" || a.Domain == "" || a.Link == "" {
+		return a, errors.New("token, record, and link arguments required")
+	}
+	return a, nil
 }
 
 func main() {
-	token := os.Getenv("DNSIMPLE_TOKEN")
-	if len(os.Args) < 3 || len(os.Args) > 4 || token == "" {
-		fmt.Printf("Usage: dnslink-dnsimple DOMAIN PATH [RECORD_NAME]\n")
-		fmt.Printf("Example: dnslink-dnsimple example.com /ipfs/QmFoo\n")
-		fmt.Printf("\n")
-		fmt.Printf("The DNSIMPLE_TOKEN environment variable is required.\n")
-		fmt.Printf("\n")
-		os.Exit(1)
-	}
-	zonename := os.Args[1]
-	path := os.Args[2]
-	recordname := ""
-	if len(os.Args) == 4 {
-		recordname = os.Args[3]
-	}
-
-	client := dnsimple.NewClient(dnsimple.NewOauthTokenCredentials(token))
-
-	// Loop over all accounts to find the one containing the relevant zone.
-	accopts := &dnsimple.ListOptions{}
-	accounts, err := client.Accounts.ListAccounts(accopts)
+	args, err := parseArgs()
 	if err != nil {
-		printError(token, fmt.Sprintf("error in listAccounts: %s", err))
-		os.Exit(1)
+    fmt.Fprintln(os.Stderr, "error:", err)
+    fmt.Fprintln(os.Stderr, Usage)
+    os.Exit(-1)
 	}
-	var account string
-	var records []dnsimple.ZoneRecord
-	for _, a := range accounts.Data {
-		acc := string(a.ID)
-		zropts := &dnsimple.ZoneRecordListOptions{Name: recordname, Type: "TXT"}
-		recs, err := client.Zones.ListRecords(acc, zonename, zropts)
-		if err != nil {
-			continue
-		}
-		account = acc
-		records = recs.Data
+
+	if args.Verbose {
+		log = logging.New(os.Stderr, "", 0)
+	} else {
+		log = logging.New(ioutil.Discard, "", 0)
+	}
+
+  if err := errMain(args); err != nil {
+    fmt.Fprintln(os.Stderr, "error:", sanitizeErr(args.Token, err))
+    os.Exit(-1)
+  }
+}
+
+func sanitizeErr(token string, err error) string {
+	return strings.Replace(fmt.Sprintf("%s", err), token, "", -1)
+}
+
+func errMain(args Args) error {
+	client := dns.NewClient(dns.NewOauthTokenCredentials(args.Token))
+
+	// get the account responsible for zone, and the dnslink record if there is one.
+	acc, oldR, err := findAccountAndRecord(client, args)
+	if err != nil {
+		return err
 	}
 
 	// Create or update the _dnslink record.
-	var updatedRecord *dnsimple.ZoneRecord
-	if len(records) == 0 {
-		record := &dnsimple.ZoneRecord{
-			Type:    "TXT",
-			Name:    recordname,
-			Content: "dnslink=" + path,
-			TTL:     120,
-		}
-		response, err := client.Zones.CreateRecord(account, zonename, *record)
-		if err != nil {
-			printError(token, fmt.Sprintf("error in createRecord: %s", err))
-			os.Exit(1)
-		}
-		updatedRecord = response.Data
-	} else {
-		record := records[0]
-		record.Content = "dnslink=" + path
-		response, err := client.Zones.UpdateRecord(account, zonename, record.ID, record)
-		if err != nil {
-			printError(token, fmt.Sprintf("error in updateRecord: %s", err))
-			os.Exit(1)
-		}
-		updatedRecord = response.Data
+	var newR *dns.ZoneRecord
+	if oldR == nil {
+		newR, err = createRecord(client, args, acc)
+	} else { // got an old record to update
+		newR, err = updateRecord(client, args, acc, oldR)
+	}
+	if err != nil {
+		return err
 	}
 
-	fmt.Printf("updated TXT %s.%s to %s\n", recordname, zonename, updatedRecord.Content)
+	fmt.Printf("updated TXT %s.%s to %s\n", newR.Name, args.Domain, newR.Content)
+	return nil
+}
+
+// findAccountAndRecord finds the right account that can update the desired record
+// if we find the specific record to update, return it too.
+func findAccountAndRecord(c *dns.Client, args Args) (acc string, rec *dns.ZoneRecord, err error) {
+	acc, recs, err := findAccountForZone(c, args)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// find record to replace, if any
+	var oldR *dns.ZoneRecord
+	for _, r := range recs {
+		if strings.HasPrefix(r.Content, "dnslink") {
+			oldR = &r
+		}
+	}
+	if oldR == nil {
+		log.Println("existing dnslink record: not found")
+	} else {
+		log.Println("existing dnslink record:", oldR)
+	}
+
+	return acc, oldR, nil
+}
+
+func findAccountForZone(c *dns.Client, args Args) (acc string, recs []dns.ZoneRecord, err error) {
+	// Loop over all accounts to find the one containing the relevant zone.
+	accopts := &dns.ListOptions{}
+	accounts, err := c.Accounts.ListAccounts(accopts)
+	if err != nil {
+		return "", nil, err
+	}
+	log.Printf("found %d accounts for token: %s\n", len(accounts.Data), accounts.Data)
+
+	for _, a := range accounts.Data {
+		acc := fmt.Sprintf("%d", a.ID)
+		zropts := &dns.ZoneRecordListOptions{Name: args.RecName, Type: TXT}
+		recs, err := c.Zones.ListRecords(acc, args.Domain, zropts)
+		if err != nil {
+			log.Printf("error listing records of account %s: %s", acc, err)
+			continue
+		}
+
+		records := recs.Data
+		log.Printf("found domain %s in account %s with %d records\n",
+				args.Domain, acc, len(records))
+		return acc, records, nil
+	}
+
+	return "", nil, fmt.Errorf("did not find account for: %s", args.Domain)
+}
+
+
+func createRecord(c *dns.Client, args Args, acc string) (newR *dns.ZoneRecord, err error) {
+	newR = newRecord(args)
+	log.Println("will CreateRecord:", newR)
+	res, err := c.Zones.CreateRecord(acc, args.Domain, *newR)
+	if err != nil {
+		return nil, fmt.Errorf("CreateRecord: %v", err)
+	}
+	log.Println("did CreateRecord:", res.Data)
+	return res.Data, nil
+}
+
+func updateRecord(c *dns.Client, args Args, acc string, oldR *dns.ZoneRecord) (newR *dns.ZoneRecord, err error) {
+	// just update value
+	oldR.Content = DnslinkPrefix + args.Link
+
+	// we only want to change the value.
+	// looking at the API, it should only update what we ask it to update.
+	// (i was getting "regions not available in your plan")
+	newR = newRecord(args)
+	newR.ID = oldR.ID
+	newR.ZoneID = oldR.ZoneID
+	newR.ParentID = oldR.ParentID
+
+	log.Println("will UpdateRecord:", newR)
+	res, err := c.Zones.UpdateRecord(acc, args.Domain, newR.ID, *newR)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateRecord: %v", err)
+	}
+	log.Println("did UpdateRecord:", res.Data)
+	return res.Data, nil
+}
+
+func newRecord(args Args) *dns.ZoneRecord {
+	return &dns.ZoneRecord{
+		Type:    TXT,
+		Name:    args.RecName,
+		Content: DnslinkPrefix + args.Link,
+		TTL:     args.TTL,
+	}
 }


### PR DESCRIPTION
I refactored the code because it was hard to debug
and hard to understand what was going wrong.

Changes include:

- better argument input and documentation
- args now use flags, positionals were wonky and error prone
- error checking on inputs
- added -v, --verbose flag
- added logging module w/ -v
- better error handling
- added --ttl flag
- token as an arg, not env var
- bugfix: fmt.Sprintf to convert account int
- bugfix: do not require setting all record vars (regions bug)

---

Why token as an arg?

env vars leak, they are bad for common usage. better to:

    dnslink-dnsimple -t $(cat .dnsimple-token)

Yes, infra deployments tend to use env vars. it's easy to
turn an env var into an arg for such use cases:

    dnslink-dnsimple -t $(echo DNSIMPLE_TOKEN)

But it is hard to avoid the leakage in other settings.
-